### PR TITLE
PopupにDLsiteとサイドパネルを開くボタンを追加

### DIFF
--- a/src/entrypoints/popup/App.css
+++ b/src/entrypoints/popup/App.css
@@ -4,39 +4,3 @@
   padding: 2rem;
   text-align: center;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #54bc4ae0);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -3,12 +3,12 @@ import "./App.css";
 function App() {
   return (
     <>
-      <button onClick={OpenDLsite}>DLsiteを開く</button>
+      <button onClick={openDLsite}>DLsiteを開く</button>
     </>
   );
 }
 
-async function OpenDLsite() {
+async function openDLsite() {
   const sidePanelPromise = browser.windows
     .getCurrent()
     .then((win) =>

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -1,35 +1,46 @@
-import { useState } from "react";
-import reactLogo from "@/assets/react.svg";
-import wxtLogo from "/wxt.svg";
 import "./App.css";
 
-function App() {
-  const [count, setCount] = useState(0);
+let currentWindowId: number | undefined;
 
+browser.windows.getCurrent().then((win) => {
+  currentWindowId = win.id;
+});
+
+function App() {
   return (
     <>
-      <div>
-        <a href="https://wxt.dev" target="_blank" rel="noreferrer">
-          <img src={wxtLogo} className="logo" alt="WXT logo" />
-        </a>
-        <a href="https://react.dev" target="_blank" rel="noreferrer">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>WXT + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the WXT and React logos to learn more
-      </p>
+      <button onClick={OpenDLsite}>DLsiteを開く</button>
     </>
   );
+}
+
+async function OpenDLsite() {
+  if (!currentWindowId) return;
+
+  browser.sidePanel.open({ windowId: currentWindowId }).catch(console.error);
+
+  const [activeTab] = await browser.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+
+  const dlsiteUrl = "https://www.dlsite.com/home/";
+
+  if (
+    activeTab?.id &&
+    (activeTab.url === "chrome://newtab/" || activeTab.url === "about:newtab")
+  ) {
+    await browser.tabs.update(activeTab.id, {
+      url: dlsiteUrl,
+      active: true,
+    });
+  } else {
+    await browser.tabs.create({
+      windowId: currentWindowId,
+      url: dlsiteUrl,
+      active: true,
+    });
+  }
 }
 
 export default App;

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -1,11 +1,5 @@
 import "./App.css";
 
-let currentWindowId: number | undefined;
-
-browser.windows.getCurrent().then((win) => {
-  currentWindowId = win.id;
-});
-
 function App() {
   return (
     <>
@@ -15,9 +9,14 @@ function App() {
 }
 
 async function OpenDLsite() {
-  if (!currentWindowId) return;
-
-  browser.sidePanel.open({ windowId: currentWindowId }).catch(console.error);
+  const sidePanelPromise = browser.windows
+    .getCurrent()
+    .then((win) =>
+      win.id !== undefined
+        ? browser.sidePanel.open({ windowId: win.id })
+        : undefined,
+    )
+    .catch(console.error);
 
   const [activeTab] = await browser.tabs.query({
     active: true,
@@ -35,12 +34,14 @@ async function OpenDLsite() {
       active: true,
     });
   } else {
+    const win = await browser.windows.getCurrent();
     await browser.tabs.create({
-      windowId: currentWindowId,
+      windowId: win.id,
       url: dlsiteUrl,
       active: true,
     });
   }
+  await sidePanelPromise;
 }
 
 export default App;

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Default Popup Title</title>
+    <title>Popup</title>
     <meta name="manifest.type" content="browser_action" />
   </head>
   <body>

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "wxt";
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
+  webExt: {
+    startUrls: ["chrome://newtab/"],
+  },
   manifest: {
     name: "DLsite Browsing Companion",
     description: "",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,15 +3,12 @@ import { defineConfig } from "wxt";
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
-  webExt: {
-    startUrls: ["https://www.dlsite.com/index.html"],
-  },
   manifest: {
     name: "DLsite Browsing Companion",
     description: "",
     permissions: ["sidePanel"],
     side_panel: {
-      default_path: "entrypoints/sidepanel.html",
+      default_path: "sidepanel.html",
     },
   },
   srcDir: "src",


### PR DESCRIPTION
Close #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ポップアップに「DLサイトを開く」ボタンを追加。クリックでサイドパネルを開き、必要に応じて新しいタブまたは既存タブでDLsiteを表示します。

* **スタイル**
  * ロゴのアニメーションと関連スタイル（ホバー効果やカード表示など）を削除し、デザインを簡素化。

* **その他**
  * ポップアップの表示言語を日本語に変更。サイドパネルの参照先と起動時の初期ページ設定を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->