### PR TITLE
response.idを使用した会話の継続機能を追加

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { CharacterId } from "@/utils/types.ts";
+import { CharacterId, CommentStreamEvent } from "@/utils/types.ts";
 import {
   CHARACTER_ID_KEY,
   DEBUG_MODE_KEY,
@@ -338,8 +338,24 @@ async function generateComment<U extends Usecase>(
 
     await sendMessage("comment:stream-start");
 
+    let buffer = "";
+
     for await (const chunk of stream) {
-      await sendMessage("comment:stream-chunk", chunk);
+      buffer += chunk;
+
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+
+        await handleCommentStreamLine(line);
+
+        newlineIndex = buffer.indexOf("\n");
+      }
+
+      if (buffer.trim().length > 0) {
+        await handleCommentStreamLine(buffer);
+      }
     }
   } catch (err) {
     if (err instanceof Error) {
@@ -403,4 +419,31 @@ async function waitForTabComplete(tabId: number): Promise<void> {
         reject(err);
       });
   });
+}
+
+async function handleCommentStreamLine(line: string): Promise<void> {
+  const trimmedLine = line.trim();
+
+  if (trimmedLine.length === 0) {
+    return;
+  }
+
+  const event: unknown = JSON.parse(trimmedLine);
+
+  if (!isCommentStreamEvent(event)) {
+    console.error("Unknown comment stream event:", event);
+    return;
+  }
+
+  await sendMessage("comment:stream-chunk", event.text);
+}
+
+function isCommentStreamEvent(value: unknown): value is CommentStreamEvent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const event = value as Record<string, unknown>;
+
+  return event.type === "delta" && typeof event.text === "string";
 }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -297,11 +297,18 @@ async function generateComment<U extends Usecase>(
     );
   }
 
+  const previousResponseIdKey: `local:${string}` = `local:xaiPreviousResponseId:${characterId}`;
+
+  const previousResponseId = await storage.getItem<string>(
+    previousResponseIdKey,
+  );
+
   const body = JSON.stringify({
     characterId,
     usecase,
     payload: payload,
     debugMode,
+    ...(previousResponseId ? { previousResponseId } : {}),
   });
 
   if (isStreaming) {
@@ -348,13 +355,13 @@ async function generateComment<U extends Usecase>(
         const line = buffer.slice(0, newlineIndex);
         buffer = buffer.slice(newlineIndex + 1);
 
-        await handleCommentStreamLine(line);
+        await handleCommentStreamLine(line, previousResponseIdKey);
 
         newlineIndex = buffer.indexOf("\n");
       }
 
       if (buffer.trim().length > 0) {
-        await handleCommentStreamLine(buffer);
+        await handleCommentStreamLine(buffer, previousResponseIdKey);
       }
     }
   } catch (err) {
@@ -421,7 +428,10 @@ async function waitForTabComplete(tabId: number): Promise<void> {
   });
 }
 
-async function handleCommentStreamLine(line: string): Promise<void> {
+async function handleCommentStreamLine(
+  line: string,
+  previousResponseIdKey: `local:${string}`,
+): Promise<void> {
   const trimmedLine = line.trim();
 
   if (trimmedLine.length === 0) {
@@ -435,7 +445,15 @@ async function handleCommentStreamLine(line: string): Promise<void> {
     return;
   }
 
-  await sendMessage("comment:stream-chunk", event.text);
+  if (event.type === "delta") {
+    await sendMessage("comment:stream-chunk", event.text);
+    return;
+  }
+
+  if (event.type === "done") {
+    await storage.setItem(previousResponseIdKey, event.responseId);
+    return;
+  }
 }
 
 function isCommentStreamEvent(value: unknown): value is CommentStreamEvent {
@@ -445,5 +463,13 @@ function isCommentStreamEvent(value: unknown): value is CommentStreamEvent {
 
   const event = value as Record<string, unknown>;
 
-  return event.type === "delta" && typeof event.text === "string";
+  if (event.type === "delta") {
+    return typeof event.text === "string";
+  }
+
+  if (event.type === "done") {
+    return typeof event.responseId === "string";
+  }
+
+  return false;
 }

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -359,10 +359,10 @@ async function generateComment<U extends Usecase>(
 
         newlineIndex = buffer.indexOf("\n");
       }
+    }
 
-      if (buffer.trim().length > 0) {
-        await handleCommentStreamLine(buffer, previousResponseIdKey);
-      }
+    if (buffer.trim().length > 0) {
+      await handleCommentStreamLine(buffer, previousResponseIdKey);
     }
   } catch (err) {
     if (err instanceof Error) {

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -438,7 +438,13 @@ async function handleCommentStreamLine(
     return;
   }
 
-  const event: unknown = JSON.parse(trimmedLine);
+  let event: unknown;
+  try {
+    event = JSON.parse(trimmedLine);
+  } catch (err) {
+    console.error("Failed to parse comment stream line:", trimmedLine, err);
+    return;
+  }
 
   if (!isCommentStreamEvent(event)) {
     console.error("Unknown comment stream event:", event);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -159,3 +159,8 @@ export const homes: readonly Home[] = [
   new Home("/home/tool", "DLsite 制作ソフト・素材フロア（全年齢）"),
   new Home("/maniax/tool", "DLsite 制作ソフト・素材フロア（R18）"),
 ];
+
+export type CommentStreamEvent = {
+  type: "delta";
+  text: string;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -160,7 +160,12 @@ export const homes: readonly Home[] = [
   new Home("/maniax/tool", "DLsite 制作ソフト・素材フロア（R18）"),
 ];
 
-export type CommentStreamEvent = {
-  type: "delta";
-  text: string;
-};
+export type CommentStreamEvent =
+  | {
+      type: "delta";
+      text: string;
+    }
+  | {
+      type: "done";
+      responseId: string;
+    };


### PR DESCRIPTION
Close #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * ストリーミング応答処理を刷新し、受信データを行区切りのイベントとして安定的に処理するようになりました。
  * 前回の応答を識別して再利用する仕組みにより、複数リクエスト間での応答継続性と信頼性を向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saitokento/dlsite-browsing-companion/pull/111)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saitokento/dlsite-browsing-companion/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->