### PR TITLE
会話履歴のセーブ・ロード機能を追加

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,8 +1,14 @@
-import { CharacterId, CommentStreamEvent } from "@/utils/types.ts";
+import {
+  CharacterId,
+  CommentStreamEvent,
+  CommentHistoryItem,
+  CurrentComment,
+} from "@/utils/types.ts";
 import {
   CHARACTER_ID_KEY,
   DEBUG_MODE_KEY,
   isCharacterId,
+  pruneExpiredCommentHistory,
 } from "@/utils/exports";
 
 const BACKEND_API_KEY = import.meta.env.WXT_BACKEND_API_KEY;
@@ -298,6 +304,7 @@ async function generateComment<U extends Usecase>(
   }
 
   const previousResponseIdKey: `local:${string}` = `local:xaiPreviousResponseId:${characterId}`;
+  const commentHistoryKey: `local:${string}` = `local:commentHistory:${characterId}`;
 
   const previousResponseId = await storage.getItem<string>(
     previousResponseIdKey,
@@ -345,6 +352,11 @@ async function generateComment<U extends Usecase>(
 
     await sendMessage("comment:stream-start");
 
+    const currentComment: CurrentComment = {
+      text: "",
+      createdAt: new Date().toISOString(),
+    };
+
     let buffer = "";
 
     for await (const chunk of stream) {
@@ -355,14 +367,24 @@ async function generateComment<U extends Usecase>(
         const line = buffer.slice(0, newlineIndex);
         buffer = buffer.slice(newlineIndex + 1);
 
-        await handleCommentStreamLine(line, previousResponseIdKey);
+        await handleCommentStreamLine(
+          line,
+          previousResponseIdKey,
+          commentHistoryKey,
+          currentComment,
+        );
 
         newlineIndex = buffer.indexOf("\n");
       }
     }
 
     if (buffer.trim().length > 0) {
-      await handleCommentStreamLine(buffer, previousResponseIdKey);
+      await handleCommentStreamLine(
+        buffer,
+        previousResponseIdKey,
+        commentHistoryKey,
+        currentComment,
+      );
     }
   } catch (err) {
     if (err instanceof Error) {
@@ -431,6 +453,8 @@ async function waitForTabComplete(tabId: number): Promise<void> {
 async function handleCommentStreamLine(
   line: string,
   previousResponseIdKey: `local:${string}`,
+  commentHistoryKey: `local:${string}`,
+  currentComment: CurrentComment,
 ): Promise<void> {
   const trimmedLine = line.trim();
 
@@ -452,12 +476,14 @@ async function handleCommentStreamLine(
   }
 
   if (event.type === "delta") {
+    currentComment.text += event.text;
     await sendMessage("comment:stream-chunk", event.text);
     return;
   }
 
   if (event.type === "done") {
     await storage.setItem(previousResponseIdKey, event.responseId);
+    await appendCommentToHistoryInStorage(commentHistoryKey, currentComment);
     return;
   }
 }
@@ -478,4 +504,54 @@ function isCommentStreamEvent(value: unknown): value is CommentStreamEvent {
   }
 
   return false;
+}
+
+async function getCommentHistory(
+  commentHistoryKey: `local:${string}`,
+): Promise<CommentHistoryItem[]> {
+  const commentHistory =
+    (await storage.getItem<CommentHistoryItem[]>(commentHistoryKey)) ?? [];
+  const prunedCommentHistory: CommentHistoryItem[] =
+    pruneExpiredCommentHistory(commentHistory);
+
+  if (prunedCommentHistory.length !== commentHistory.length) {
+    await storage.setItem(commentHistoryKey, prunedCommentHistory);
+  }
+
+  return prunedCommentHistory;
+}
+
+async function setCommentHistory(
+  commentHistoryKey: `local:${string}`,
+  commentHistory: CommentHistoryItem[],
+): Promise<void> {
+  console.trace("setCommentHistory called", {
+    commentHistoryKey,
+    length: commentHistory.length,
+  });
+  await storage.setItem(
+    commentHistoryKey,
+    pruneExpiredCommentHistory(commentHistory),
+  );
+}
+
+async function appendCommentToHistoryInStorage(
+  commentHistoryKey: `local:${string}`,
+  comment: CurrentComment,
+): Promise<void> {
+  const text = comment.text.trim();
+
+  if (text.length === 0) {
+    return;
+  }
+
+  const commentHistory = await getCommentHistory(commentHistoryKey);
+
+  await setCommentHistory(commentHistoryKey, [
+    ...commentHistory,
+    {
+      text: comment.text,
+      createdAt: comment.createdAt,
+    },
+  ]);
 }

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -16,7 +16,9 @@ function App() {
     loadCommentHistory()
       .then((commentHistory) => {
         if (active) {
-          setCommentList(commentHistory);
+          setCommentList((prev) =>
+            prev.length === 0 ? commentHistory : [...commentHistory, ...prev],
+          );
         }
       })
       .catch((err) => {

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -1,10 +1,28 @@
 import { useEffect, useState } from "react";
+import { CharacterId, CommentHistoryItem } from "@/utils/types.ts";
+import {
+  CHARACTER_ID_KEY,
+  isCharacterId,
+  pruneExpiredCommentHistory,
+} from "@/utils/exports";
 import "./App.css";
 
 function App() {
-  const [commentList, setCommentList] = useState<string[]>([]);
+  const [commentList, setCommentList] = useState<CommentHistoryItem[]>([]);
 
   useEffect(() => {
+    let active = true;
+
+    loadCommentHistory()
+      .then((commentHistory) => {
+        if (active) {
+          setCommentList(commentHistory);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load comment history:", err);
+      });
+
     const removeStreamStartListener = onMessage("comment:stream-start", () => {
       setCommentList(startNewComment);
     });
@@ -17,6 +35,7 @@ function App() {
     );
 
     return () => {
+      active = false;
       removeStreamStartListener();
       removeStreamChunkListener();
     };
@@ -25,31 +44,75 @@ function App() {
   return (
     <div className="comment-list">
       {commentList.map((item, index) => (
-        <div key={index} className="comment-item">
-          <p className="comment-text">{item}</p>
+        <div key={`${item.createdAt}-${index}`} className="comment-item">
+          <p className="comment-text">{item.text}</p>
         </div>
       ))}
     </div>
   );
 }
 
-function startNewComment(prev: string[]): string[] {
-  if (prev.length < 1 || prev[prev.length - 1] !== "") {
-    return [...prev, ""];
+function startNewComment(prev: CommentHistoryItem[]): CommentHistoryItem[] {
+  if (prev.length < 1 || prev[prev.length - 1].text !== "") {
+    return [
+      ...prev,
+      {
+        text: "",
+        createdAt: new Date().toISOString(),
+      },
+    ];
   }
+
   return prev;
 }
 
-function appendChunkToLastComment(prev: string[], chunk: string): string[] {
+function appendChunkToLastComment(
+  prev: CommentHistoryItem[],
+  chunk: string,
+): CommentHistoryItem[] {
   const updated = [...prev];
+
   if (updated.length === 0) {
     console.warn(
       "'comment:stream-chunk' received before 'comment:stream-start'.",
     );
-    updated.push("");
+
+    updated.push({
+      text: "",
+      createdAt: new Date().toISOString(),
+    });
   }
-  updated[updated.length - 1] += chunk;
+
+  const lastIndex = updated.length - 1;
+  const lastItem = updated[lastIndex];
+
+  updated[lastIndex] = {
+    ...lastItem,
+    text: lastItem.text + chunk,
+  };
+
   return updated;
+}
+
+async function loadCommentHistory(): Promise<CommentHistoryItem[]> {
+  let characterId =
+    (await storage.getItem<CharacterId>(CHARACTER_ID_KEY)) ?? "default";
+
+  if (!isCharacterId(characterId)) {
+    characterId = "default";
+  }
+
+  const commentHistoryKey: `local:${string}` = `local:commentHistory:${characterId}`;
+
+  const commentHistory =
+    (await storage.getItem<CommentHistoryItem[]>(commentHistoryKey)) ?? [];
+  const prunedCommentHistory = pruneExpiredCommentHistory(commentHistory);
+
+  if (prunedCommentHistory.length !== commentHistory.length) {
+    await storage.setItem(commentHistoryKey, prunedCommentHistory);
+  }
+
+  return prunedCommentHistory;
 }
 
 export default App;

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -108,13 +108,8 @@ async function loadCommentHistory(): Promise<CommentHistoryItem[]> {
 
   const commentHistory =
     (await storage.getItem<CommentHistoryItem[]>(commentHistoryKey)) ?? [];
-  const prunedCommentHistory = pruneExpiredCommentHistory(commentHistory);
 
-  if (prunedCommentHistory.length !== commentHistory.length) {
-    await storage.setItem(commentHistoryKey, prunedCommentHistory);
-  }
-
-  return prunedCommentHistory;
+  return pruneExpiredCommentHistory(commentHistory);
 }
 
 export default App;

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CharacterId, CommentHistoryItem } from "@/utils/types.ts";
 import {
   CHARACTER_ID_KEY,
@@ -9,6 +9,7 @@ import "./App.css";
 
 function App() {
   const [commentList, setCommentList] = useState<CommentHistoryItem[]>([]);
+  const hasStreamEntryRef = useRef(false);
 
   useEffect(() => {
     let active = true;
@@ -26,13 +27,24 @@ function App() {
       });
 
     const removeStreamStartListener = onMessage("comment:stream-start", () => {
+      hasStreamEntryRef.current = true;
       setCommentList(startNewComment);
     });
 
     const removeStreamChunkListener = onMessage(
       "comment:stream-chunk",
       (message) => {
-        setCommentList((prev) => appendChunkToLastComment(prev, message.data));
+        setCommentList((prev) => {
+          const [next, created] = appendChunkToLastComment(
+            prev,
+            message.data,
+            hasStreamEntryRef.current,
+          );
+          if (created) {
+            hasStreamEntryRef.current = true;
+          }
+          return next;
+        });
       },
     );
 
@@ -71,10 +83,12 @@ function startNewComment(prev: CommentHistoryItem[]): CommentHistoryItem[] {
 function appendChunkToLastComment(
   prev: CommentHistoryItem[],
   chunk: string,
-): CommentHistoryItem[] {
+  hasStreamEntry: boolean,
+): [CommentHistoryItem[], boolean] {
   const updated = [...prev];
+  let created = false;
 
-  if (updated.length === 0) {
+  if (!hasStreamEntry) {
     console.warn(
       "'comment:stream-chunk' received before 'comment:stream-start'.",
     );
@@ -83,6 +97,7 @@ function appendChunkToLastComment(
       text: "",
       createdAt: new Date().toISOString(),
     });
+    created = true;
   }
 
   const lastIndex = updated.length - 1;
@@ -93,7 +108,7 @@ function appendChunkToLastComment(
     text: lastItem.text + chunk,
   };
 
-  return updated;
+  return [updated, created];
 }
 
 async function loadCommentHistory(): Promise<CommentHistoryItem[]> {

--- a/src/utils/exports.ts
+++ b/src/utils/exports.ts
@@ -1,5 +1,10 @@
+import { CommentHistoryItem } from "@/utils/types.ts";
+
 export const AUTO_COMMENT_ENABLED_KEY = "local:autoCommentEnabled";
 export const CHARACTER_ID_KEY = "local:characterId";
+export const COMMENT_HISTORY_RETENTION_DAYS = 30;
+export const COMMENT_HISTORY_RETENTION_MS =
+  COMMENT_HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export const DEBUG_MODE_KEY = "local:debugMode";
 export const ENABLED_HOME_PATHS_KEY = "local:enabledHomePaths";
 
@@ -36,4 +41,20 @@ export async function waitDomReady(timeoutMs: number): Promise<boolean> {
   }
 
   return isDomReady;
+}
+
+export function pruneExpiredCommentHistory(
+  commentHistory: CommentHistoryItem[],
+): CommentHistoryItem[] {
+  const thresholdTime = Date.now() - COMMENT_HISTORY_RETENTION_MS;
+
+  return commentHistory.filter((item) => {
+    const createdAtTime = Date.parse(item.createdAt);
+
+    if (Number.isNaN(createdAtTime)) {
+      return false;
+    }
+
+    return createdAtTime >= thresholdTime;
+  });
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -169,3 +169,13 @@ export type CommentStreamEvent =
       type: "done";
       responseId: string;
     };
+
+export type CommentHistoryItem = {
+  text: string;
+  createdAt: string;
+};
+
+export type CurrentComment = {
+  text: string;
+  createdAt: string;
+};


### PR DESCRIPTION
Close #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ストリーミング中のコメントが逐次UIに表示され、完了したコメントはキャラクター別にローカル保存されます。  
  * サイドパネルのコメント一覧が履歴アイテム（テキスト＋作成日時）として表示され、読み込み時に過去履歴を結合します。  
  * コメント履歴の有効期限を30日で判定し、期限切れ項目を自動で削除（プルーニング）します。

* **Bug Fixes**
  * ストリーム受信中の状態管理とコンポーネントのクリーンアップを改善し、競合やメモリ不整合を抑制します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saitokento/dlsite-browsing-companion/pull/112)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->