### PR TITLE
会話履歴のリセット機能を追加

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -525,10 +525,6 @@ async function setCommentHistory(
   commentHistoryKey: `local:${string}`,
   commentHistory: CommentHistoryItem[],
 ): Promise<void> {
-  console.trace("setCommentHistory called", {
-    commentHistoryKey,
-    length: commentHistory.length,
-  });
   await storage.setItem(
     commentHistoryKey,
     pruneExpiredCommentHistory(commentHistory),

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -152,6 +152,8 @@ async function handleClearSelectedCharacterConversationData(
   characterId: CharacterId,
   setConversationClearMessage: (message: string | null) => void,
 ): Promise<void> {
+  setConversationClearMessage(null);
+
   const character = characters.find((item) => item.id === characterId);
   const characterName = character?.name ?? characterId;
 
@@ -174,6 +176,8 @@ async function handleClearSelectedCharacterConversationData(
 async function handleClearAllCharacterConversationData(
   setConversationClearMessage: (message: string | null) => void,
 ): Promise<void> {
+  setConversationClearMessage(null);
+
   const accepted = window.confirm(
     "全キャラクターのコメント履歴をリセットします。\nよろしいですか？",
   );

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -165,12 +165,19 @@ async function handleClearSelectedCharacterConversationData(
     return;
   }
 
-  await clearCharacterConversationData(characterId);
-  await sendMessage("options:history-reset");
+  try {
+    await clearCharacterConversationData(characterId);
+    await sendMessage("options:history-reset");
 
-  setConversationClearMessage(
-    `「${characterName}」のコメント履歴をリセットしました。`,
-  );
+    setConversationClearMessage(
+      `「${characterName}」のコメント履歴をリセットしました。`,
+    );
+  } catch (error) {
+    console.error("Failed to reset selected character conversation:", error);
+    setConversationClearMessage(
+      `「${characterName}」のコメント履歴リセットに失敗しました。`,
+    );
+  }
 }
 
 async function handleClearAllCharacterConversationData(
@@ -186,15 +193,24 @@ async function handleClearAllCharacterConversationData(
     return;
   }
 
-  await Promise.all(
-    characters.map((character) => clearCharacterConversationData(character.id)),
-  );
+  try {
+    await Promise.all(
+      characters.map((character) =>
+        clearCharacterConversationData(character.id),
+      ),
+    );
 
-  await sendMessage("options:history-reset");
+    await sendMessage("options:history-reset");
 
-  setConversationClearMessage(
-    "全キャラクターのコメント履歴をリセットしました。",
-  );
+    setConversationClearMessage(
+      "全キャラクターのコメント履歴をリセットしました。",
+    );
+  } catch (error) {
+    console.error("Failed to reset all character conversation data:", error);
+    setConversationClearMessage(
+      "全キャラクターのコメント履歴リセットに失敗しました。",
+    );
+  }
 }
 
 async function handleHomePathChange(

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -14,6 +14,9 @@ function App() {
     useState<CharacterId>("default");
   const [enabledHomePaths, setEnabledHomePaths] = useState<string[]>([]);
   const [debugMode, setDebugMode] = useState(false);
+  const [conversationClearMessage, setConversationClearMessage] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     loadSelectedCharacter(setSelectedCharacter);
@@ -37,6 +40,35 @@ function App() {
           </option>
         ))}
       </select>
+
+      <h2>コメント履歴のリセット</h2>
+
+      <div className="conversation-data-actions">
+        <button
+          type="button"
+          onClick={() =>
+            handleClearSelectedCharacterConversationData(
+              selectedCharacter,
+              setConversationClearMessage,
+            )
+          }
+        >
+          現在選択中のキャラクターのコメント履歴をリセット
+        </button>
+
+        <button
+          type="button"
+          onClick={() =>
+            handleClearAllCharacterConversationData(setConversationClearMessage)
+          }
+        >
+          全キャラクターの会話履歴のコメント履歴をリセット
+        </button>
+      </div>
+
+      {conversationClearMessage !== null && (
+        <p className="conversation-clear-message">{conversationClearMessage}</p>
+      )}
 
       <h2>ボタンを表示するフロア</h2>
       <div className="home-checkbox-table">
@@ -116,6 +148,51 @@ async function handleCharacterChange(
   await storage.setItem(CHARACTER_ID_KEY, characterId);
 }
 
+async function handleClearSelectedCharacterConversationData(
+  characterId: CharacterId,
+  setConversationClearMessage: (message: string | null) => void,
+): Promise<void> {
+  const character = characters.find((item) => item.id === characterId);
+  const characterName = character?.name ?? characterId;
+
+  const accepted = window.confirm(
+    `「${characterName}」のコメント履歴をリセットします。\nよろしいですか？`,
+  );
+
+  if (!accepted) {
+    return;
+  }
+
+  await clearCharacterConversationData(characterId);
+  await sendMessage("options:history-reset");
+
+  setConversationClearMessage(
+    `「${characterName}」のコメント履歴をリセットしました。`,
+  );
+}
+
+async function handleClearAllCharacterConversationData(
+  setConversationClearMessage: (message: string | null) => void,
+): Promise<void> {
+  const accepted = window.confirm(
+    "全キャラクターのコメント履歴をリセットします。\nよろしいですか？",
+  );
+
+  if (!accepted) {
+    return;
+  }
+
+  await Promise.all(
+    characters.map((character) => clearCharacterConversationData(character.id)),
+  );
+
+  await sendMessage("options:history-reset");
+
+  setConversationClearMessage(
+    "全キャラクターのコメント履歴をリセットしました。",
+  );
+}
+
 async function handleHomePathChange(
   event: React.ChangeEvent<HTMLInputElement>,
   homePath: string,
@@ -130,6 +207,15 @@ async function handleHomePathChange(
 
   setEnabledHomePaths(nextEnabledHomePaths);
   await storage.setItem(ENABLED_HOME_PATHS_KEY, nextEnabledHomePaths);
+}
+
+async function clearCharacterConversationData(
+  characterId: CharacterId,
+): Promise<void> {
+  await Promise.all([
+    storage.removeItem(`local:commentHistory:${characterId}`),
+    storage.removeItem(`local:xaiPreviousResponseId:${characterId}`),
+  ]);
 }
 
 async function loadDebugMode(setDebugMode: (debugMode: boolean) => void) {

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -48,10 +48,21 @@ function App() {
       },
     );
 
+    const removeOptionsHistoryResetListener = onMessage(
+      "options:history-reset",
+      async () => {
+        hasStreamEntryRef.current = false;
+
+        const commentHistory = await loadCommentHistory();
+        setCommentList(commentHistory);
+      },
+    );
+
     return () => {
       active = false;
       removeStreamStartListener();
       removeStreamChunkListener();
+      removeOptionsHistoryResetListener();
     };
   }, []);
 

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -13,10 +13,15 @@ function App() {
 
   useEffect(() => {
     let active = true;
+    let historyLoadSeq = 0;
 
+    const nextSeq = () => ++historyLoadSeq;
+    const isLatest = (seq: number) => active && seq === historyLoadSeq;
+
+    const initialSeq = nextSeq();
     loadCommentHistory()
       .then((commentHistory) => {
-        if (active) {
+        if (isLatest(initialSeq)) {
           setCommentList((prev) =>
             prev.length === 0 ? commentHistory : [...commentHistory, ...prev],
           );
@@ -52,13 +57,18 @@ function App() {
       "options:history-reset",
       async () => {
         hasStreamEntryRef.current = false;
+        const resetSeq = nextSeq();
 
         try {
           const commentHistory = await loadCommentHistory();
-          setCommentList(commentHistory);
+          if (isLatest(resetSeq)) {
+            setCommentList(commentHistory);
+          }
         } catch (err) {
           console.error("Failed to reload comment history after reset:", err);
-          setCommentList([]);
+          if (isLatest(resetSeq)) {
+            setCommentList([]);
+          }
         }
       },
     );

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -53,8 +53,13 @@ function App() {
       async () => {
         hasStreamEntryRef.current = false;
 
-        const commentHistory = await loadCommentHistory();
-        setCommentList(commentHistory);
+        try {
+          const commentHistory = await loadCommentHistory();
+          setCommentList(commentHistory);
+        } catch (err) {
+          console.error("Failed to reload comment history after reset:", err);
+          setCommentList([]);
+        }
       },
     );
 

--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -3,6 +3,7 @@ import { defineExtensionMessaging } from "@webext-core/messaging";
 export interface ProtocolMap {
   "popup:comment-triggered": () => void;
   "popup:wait-dom-ready"(data: { tabId: number; timeoutMs?: number }): boolean;
+  "options:history-reset": () => void;
   "content:wait-dom-ready"(data: { timeoutMs?: number }): boolean;
   "work:extracted": (data: Work) => void;
   "home:open": (data: Home) => void;


### PR DESCRIPTION
Close #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コメント履歴をリセットする機能を追加しました。現在選択中のキャラクターのみ、または全キャラクターを対象にリセットできます。
  * リセット操作後に成功／失敗のステータスメッセージを表示します。

* **改善**
  * リセット実行後、サイドパネルが履歴を再読み込みして表示を更新するようになりました。

* **その他**
  * 内部のトレースログ出力を削除しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saitokento/dlsite-browsing-companion/pull/113)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->